### PR TITLE
fix screen redraw issues

### DIFF
--- a/lib/counters.lua
+++ b/lib/counters.lua
@@ -3,6 +3,7 @@ counters = {}
 function counters.init()
     counters.ui = metro.init(counters.screenminder,1/15)
     counters.ui.frame = 1
+    counters.fps = 15
     counters.ui:start()
 
     counters.transport = metro.init(counters.sceneminder,1/5)
@@ -14,7 +15,7 @@ function counters.screenminder()
     if counters.ui ~= nil then
         counters.ui.frame = counters.ui.frame + 1
     end
-    redraw()
+    fn.dirty_screen(true)
 end
 
 function counters.sceneminder()
@@ -26,7 +27,21 @@ function counters.sceneminder()
             track:buffer_render()
         end
     end
-    redraw_scene()
+    fn.dirty_scene(true)
+end
+
+function counters.redraw_clock()
+  while true do
+    if fn.dirty_screen() then
+      redraw()
+      fn.dirty_screen(false)
+    end
+    if fn.dirty_scene() then
+      redraw_scene()
+      fn.dirty_scene(false)
+    end
+    clock.sleep(1 / counters.fps)
+  end
 end
 
 return counters

--- a/lib/functions.lua
+++ b/lib/functions.lua
@@ -30,4 +30,12 @@ function fn.toggle_playback()
     end
 end
 
+function rerun()
+  norns.script.load(norns.state.script)
+end
+
+function r()
+    rerun()
+end
+
 return fn

--- a/waver.lua
+++ b/waver.lua
@@ -15,19 +15,6 @@
 
 include("waver/lib/includes")
 
-function redraw()
-    if not fn.dirty_screen() then return end
-    page:render()
-    fn.dirty_screen(false)
-end
-
-function redraw_scene()
-    if not fn.dirty_scene() then return end
-    scene:render()
-    fn.dirty_scene(false)
-    print("redrawing scene")
-end
-
 function init()
     scene.init()
     num_tracks = 4
@@ -36,10 +23,7 @@ function init()
     active_track = 1
     page.init()
     counters.init()
-    fn.dirty_screen(true)
-    fn.dirty_scene(true)
-    redraw()
-    redraw_scene()
+    redraw_clock_id = clock.run(counters.redraw_clock)
     print("init finished")
 end
 
@@ -62,4 +46,16 @@ function key(n,z)
         fn.dirty_scene(true)
     end
     fn.dirty_screen(true)
+end
+
+function redraw()
+    if not fn.dirty_screen() then return end
+    page:render()
+    fn.dirty_screen(false)
+end
+
+function redraw_scene()
+    if not fn.dirty_scene() then return end
+    scene:render()
+    fn.dirty_scene(false)
 end


### PR DESCRIPTION
i added a "redraw_clock" that is a while loop that's always running. this will check the dirty flags and update if they are true. now you never need to call `redraw()` or `redraw_scene()` directly - just set the flag `fn.dirty_screen(true)` and the loop will take care of the redrawing for you.

this pr also includes my favorite developer functions that i couldn't live with out: `rerun()` or `r()` in maiden to rerun your script without touching norns and doing it manually.